### PR TITLE
WindowManager: Upper level changes to expose blur effect

### DIFF
--- a/core/java/android/view/SurfaceControl.java
+++ b/core/java/android/view/SurfaceControl.java
@@ -58,6 +58,11 @@ public class SurfaceControl {
     private static native void nativeSetWindowCrop(long nativeObject, int l, int t, int r, int b);
     private static native void nativeSetLayerStack(long nativeObject, int layerStack);
 
+    private static native void nativeSetBlur(long nativeObject, float blur);
+    private static native void nativeSetBlurMaskSurface(long nativeObject, long maskLayerNativeObject);
+    private static native void nativeSetBlurMaskSampling(long nativeObject, int blurMaskSampling);
+    private static native void nativeSetBlurMaskAlphaThreshold(long nativeObject, float alpha);
+
     private static native boolean nativeClearContentFrameStats(long nativeObject);
     private static native boolean nativeGetContentFrameStats(long nativeObject, WindowContentFrameStats outStats);
     private static native boolean nativeClearAnimationFrameStats();
@@ -168,6 +173,11 @@ public class SurfaceControl {
      *
      */
     public static final int FX_SURFACE_NORMAL   = 0x00000000;
+
+    /**
+     * Surface creation flag: Creates a blur surface.
+     */
+    public static final int FX_SURFACE_BLUR = 0x00010000;
 
     /**
      * Surface creation flag: Creates a Dim surface.
@@ -381,6 +391,29 @@ public class SurfaceControl {
     public void setSize(int w, int h) {
         checkNotReleased();
         nativeSetSize(mNativeObject, w, h);
+    }
+
+    public void setBlur(float blur) {
+        checkNotReleased();
+        nativeSetBlur(mNativeObject, blur);
+    }
+
+    public void setBlurMaskSurface(SurfaceControl maskSurface) {
+        checkNotReleased();
+        if (maskSurface != null) {
+            maskSurface.checkNotReleased();
+        }
+        nativeSetBlurMaskSurface(mNativeObject, maskSurface == null ? 0:maskSurface.mNativeObject);
+    }
+
+    public void setBlurMaskSampling(int blurMaskSampling) {
+        checkNotReleased();
+        nativeSetBlurMaskSampling(mNativeObject, blurMaskSampling);
+    }
+
+    public void setBlurMaskAlphaThreshold(float alpha) {
+        checkNotReleased();
+        nativeSetBlurMaskAlphaThreshold(mNativeObject, alpha);
     }
 
     public void hide() {

--- a/core/java/android/view/Window.java
+++ b/core/java/android/view/Window.java
@@ -768,6 +768,13 @@ public abstract class Window {
         setPrivateFlags(flags, flags);
     }
 
+    /** @hide */
+    public void setBlurMaskAlphaThreshold(float alpha) {
+        final WindowManager.LayoutParams attrs = getAttributes();
+        attrs.blurMaskAlphaThreshold = alpha;
+        dispatchWindowAttributesChanged(attrs);
+    }
+
     /**
      * Convenience function to clear the flag bits as specified in flags, as
      * per {@link #setFlags}.

--- a/core/java/android/view/WindowManager.java
+++ b/core/java/android/view/WindowManager.java
@@ -1119,7 +1119,6 @@ public interface WindowManager extends ViewManager {
          * {@hide} */
         public static final int PRIVATE_FLAG_FULLY_TRANSPARENT = 0x10000000;
 
-
         /**
          * {@hide}
          */
@@ -1134,6 +1133,19 @@ public interface WindowManager extends ViewManager {
          * {@hide}
          */
         public static final int PRIVATE_FLAG_WAS_NOT_FULLSCREEN = 0x00002000;
+
+        /**
+         * Window flag: adding additional blur layer and set this as masking layer
+         * {@hide}
+         */
+        public static final int PRIVATE_FLAG_BLUR_WITH_MASKING = 0x40000000;
+
+        /**
+         * Window flag: adding additional blur layer and set this as masking layer.
+         * This is faster and ugglier than non-scaled version.
+         * {@hide}
+         */
+        public static final int PRIVATE_FLAG_BLUR_WITH_MASKING_SCALED = 0x80000000;
 
         /**
          * Control flags that are private to the platform.
@@ -1525,6 +1537,14 @@ public interface WindowManager extends ViewManager {
          */
         public long userActivityTimeout = -1;
 
+        /**
+         * Threshold value that blur masking layer uses to determine whether
+         * to use or discard the blurred color.
+         * Value should be between 0.0 and 1.0
+         * @hide
+         */
+        public float blurMaskAlphaThreshold = 0.0f;
+
         public LayoutParams() {
             super(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT);
             type = TYPE_APPLICATION;
@@ -1616,6 +1636,7 @@ public interface WindowManager extends ViewManager {
             out.writeInt(surfaceInsets.top);
             out.writeInt(surfaceInsets.right);
             out.writeInt(surfaceInsets.bottom);
+            out.writeFloat(blurMaskAlphaThreshold);
         }
         
         public static final Parcelable.Creator<LayoutParams> CREATOR
@@ -1663,6 +1684,7 @@ public interface WindowManager extends ViewManager {
             surfaceInsets.top = in.readInt();
             surfaceInsets.right = in.readInt();
             surfaceInsets.bottom = in.readInt();
+            blurMaskAlphaThreshold = in.readFloat();
         }
     
         @SuppressWarnings({"PointlessBitwiseExpression"})
@@ -1697,6 +1719,8 @@ public interface WindowManager extends ViewManager {
         public static final int SURFACE_INSETS_CHANGED = 1<<20;
         /** {@hide} */
         public static final int PREFERRED_REFRESH_RATE_CHANGED = 1 << 21;
+        /** {@hide} */
+        public static final int BLUR_MASK_ALPHA_THRESHOLD_CHANGED = 1 << 30;
         /** {@hide} */
         public static final int EVERYTHING_CHANGED = 0xffffffff;
 
@@ -1840,6 +1864,11 @@ public interface WindowManager extends ViewManager {
             if (!surfaceInsets.equals(o.surfaceInsets)) {
                 surfaceInsets.set(o.surfaceInsets);
                 changes |= SURFACE_INSETS_CHANGED;
+            }
+
+            if (blurMaskAlphaThreshold != o.blurMaskAlphaThreshold) {
+                blurMaskAlphaThreshold = o.blurMaskAlphaThreshold;
+                changes |= BLUR_MASK_ALPHA_THRESHOLD_CHANGED;
             }
 
             return changes;

--- a/core/jni/android_view_SurfaceControl.cpp
+++ b/core/jni/android_view_SurfaceControl.cpp
@@ -317,6 +317,39 @@ static void nativeSetLayerStack(JNIEnv* env, jclass clazz, jlong nativeObject, j
     }
 }
 
+static void nativeSetBlur(JNIEnv* env, jclass clazz, jlong nativeObject, jfloat blur) {
+    SurfaceControl* const ctrl = reinterpret_cast<SurfaceControl *>(nativeObject);
+    status_t err = ctrl->setBlur(blur);
+    if (err < 0 && err != NO_INIT) {
+        doThrowIAE(env);
+    }
+}
+
+static void nativeSetBlurMaskSurface(JNIEnv* env, jclass clazz, jlong nativeObject, jlong maskLayerNativeObject) {
+    SurfaceControl* const ctrl = reinterpret_cast<SurfaceControl *>(nativeObject);
+    SurfaceControl* const maskLayer = reinterpret_cast<SurfaceControl *>(maskLayerNativeObject);
+    status_t err = ctrl->setBlurMaskSurface(maskLayer);
+    if (err < 0 && err != NO_INIT) {
+        doThrowIAE(env);
+    }
+}
+
+static void nativeSetBlurMaskSampling(JNIEnv* env, jclass clazz, jlong nativeObject, jint blurMaskSampling) {
+    SurfaceControl* const ctrl = reinterpret_cast<SurfaceControl *>(nativeObject);
+    status_t err = ctrl->setBlurMaskSampling(blurMaskSampling);
+    if (err < 0 && err != NO_INIT) {
+        doThrowIAE(env);
+    }
+}
+
+static void nativeSetBlurMaskAlphaThreshold(JNIEnv* env, jclass clazz, jlong nativeObject, jfloat alpha) {
+    SurfaceControl* const ctrl = reinterpret_cast<SurfaceControl *>(nativeObject);
+    status_t err = ctrl->setBlurMaskAlphaThreshold(alpha);
+    if (err < 0 && err != NO_INIT) {
+        doThrowIAE(env);
+    }
+}
+
 static jobject nativeGetBuiltInDisplay(JNIEnv* env, jclass clazz, jint id) {
     sp<IBinder> token(SurfaceComposerClient::getBuiltInDisplay(id));
     return javaObjectForIBinder(env, token);
@@ -613,6 +646,14 @@ static JNINativeMethod sSurfaceControlMethods[] = {
             (void*)nativeSetWindowCrop },
     {"nativeSetLayerStack", "(JI)V",
             (void*)nativeSetLayerStack },
+    {"nativeSetBlur", "(JF)V",
+            (void*)nativeSetBlur },
+    {"nativeSetBlurMaskSurface", "(JJ)V",
+            (void*)nativeSetBlurMaskSurface },
+    {"nativeSetBlurMaskSampling", "(JI)V",
+            (void*)nativeSetBlurMaskSampling },
+    {"nativeSetBlurMaskAlphaThreshold", "(JF)V",
+            (void*)nativeSetBlurMaskAlphaThreshold },
     {"nativeGetBuiltInDisplay", "(I)Landroid/os/IBinder;",
             (void*)nativeGetBuiltInDisplay },
     {"nativeCreateDisplay", "(Ljava/lang/String;Z)Landroid/os/IBinder;",

--- a/core/res/res/values/cm_symbols.xml
+++ b/core/res/res/values/cm_symbols.xml
@@ -241,4 +241,7 @@
     <!-- Ignored sms packages -->
     <java-symbol type="array" name="config_ignored_sms_packages" />
 
+    <!-- Blur effects -->
+    <java-symbol type="bool" name="config_ui_blur_enabled" />
+
 </resources>

--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -2119,4 +2119,8 @@
 
     <!-- Ignored sms packages -->
     <string-array name="config_ignored_sms_packages"></string-array>
+
+    <!-- Support in Surfaceflinger for blur layers.
+         NOTE: This requires additional hardware-specific code. -->
+    <bool name="config_ui_blur_enabled">false</bool>
 </resources>

--- a/packages/SystemUI/AndroidManifest.xml
+++ b/packages/SystemUI/AndroidManifest.xml
@@ -123,6 +123,9 @@
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
+    <!-- blur surface -->
+    <uses-permission android:name="android.permission.ACCESS_SURFACE_FLINGER" />
+
     <application
         android:name=".SystemUIApplication"
         android:persistent="true"

--- a/packages/SystemUI/res/drawable/volume_dialog_bg_translucent.xml
+++ b/packages/SystemUI/res/drawable/volume_dialog_bg_translucent.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) 2014, The Linux Foundation. All rights reserved.
+     Redistribution and use in source and binary forms, with or without
+     modification, are permitted provided that the following conditions are
+     met:
+         * Redistributions of source code must retain the above copyright
+           notice, this list of conditions and the following disclaimer.
+         * Redistributions in binary form must reproduce the above
+           copyright notice, this list of conditions and the following
+           disclaimer in the documentation and/or other materials provided
+           with the distribution.
+         * Neither the name of The Linux Foundation nor the names of its
+           contributors may be used to endorse or promote products derived
+           from this software without specific prior written permission.
+
+     THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+     WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+     MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+     ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+     BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+     CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+     SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+     BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+     WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+     OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+     IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/system_primary_color_translucent" />
+    <corners
+        android:topLeftRadius="0dp"
+        android:topRightRadius="0dp"
+        android:bottomLeftRadius="@dimen/notification_material_rounded_rect_radius"
+        android:bottomRightRadius="@dimen/notification_material_rounded_rect_radius"/>
+</shape>

--- a/packages/SystemUI/res/layout/volume_dialog.xml
+++ b/packages/SystemUI/res/layout/volume_dialog.xml
@@ -17,6 +17,7 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:id="@+id/volume_dialog_bg_container"
     android:layout_marginLeft="@dimen/notification_side_padding"
     android:layout_marginRight="@dimen/notification_side_padding"
     android:background="@drawable/qs_background_primary"

--- a/packages/SystemUI/res/layout/zen_mode_panel.xml
+++ b/packages/SystemUI/res/layout/zen_mode_panel.xml
@@ -23,6 +23,7 @@
     android:orientation="vertical" >
 
     <FrameLayout
+        android:id="@+id/zen_mode_panel_bg_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:minHeight="12dp"

--- a/packages/SystemUI/res/values/colors.xml
+++ b/packages/SystemUI/res/values/colors.xml
@@ -35,6 +35,7 @@
     <color name="batterymeter_bolt_color">#FFFFFFFF</color>
     <color name="qs_batterymeter_frame_color">#FF404040</color>
     <color name="system_primary_color">#ff263238</color><!-- blue grey 900 -->
+    <color name="system_primary_color_translucent">#90aaaaaa</color><!-- blue grey 900 -->
     <color name="system_secondary_color">#ff384248</color>
     <color name="system_accent_color">#ff80CBC4</color><!-- deep teal 200 -->
     <color name="system_warning_color">#fff4511e</color><!-- deep orange 600 -->

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/BlurLayer.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/BlurLayer.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2014, The Linux Foundation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ *       copyright notice, this list of conditions and the following
+ *       disclaimer in the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of The Linux Foundation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.android.systemui.statusbar.phone;
+
+import android.graphics.PixelFormat;
+import android.util.Slog;
+import android.view.SurfaceControl;
+import android.view.SurfaceSession;
+
+import java.io.PrintWriter;
+
+public class BlurLayer {
+    private static final String TAG = "BlurLayer";
+    private static final boolean DEBUG = true;
+    private SurfaceControl mBlurSurface;
+    private int mLayer = -1;
+    private float mAlpha = 0;
+    private float mBlur = 0;
+    private int mX, mY;
+    private int mW, mH;
+    private boolean mIsShow;
+
+    public BlurLayer(SurfaceSession mFxSession, int w, int h, String tag) {
+        this(mFxSession, 0, 0, w, h, tag);
+    }
+
+    public BlurLayer(SurfaceSession mFxSession, int x, int y, int w, int h, String tag) {
+        mX = x;
+        mY = y;
+        mW = w;
+        mH = h;
+        mIsShow = false;
+
+        SurfaceControl.openTransaction();
+        try {
+            mBlurSurface = new SurfaceControl(mFxSession, TAG+"_"+tag, 16, 16, PixelFormat.OPAQUE,
+                SurfaceControl.FX_SURFACE_BLUR | SurfaceControl.HIDDEN);
+            mBlurSurface.setLayerStack(0);
+            mBlurSurface.setPosition(mX, mY);
+            mBlurSurface.setSize(mW, mH);
+        } catch (Exception e) {
+            Slog.e(TAG, "Exception creating BlurLayer surface", e);
+        } finally {
+            SurfaceControl.closeTransaction();
+        }
+    }
+
+    public void setSize(int w, int h) {
+        if (mBlurSurface != null && (mW != w || mH != h) ) {
+            SurfaceControl.openTransaction();
+            try {
+                mBlurSurface.setSize(w, h);
+                mW = w;
+                mH = h;
+            } catch (RuntimeException e) {
+                Slog.w(TAG, "Failure setting setSize immediately", e);
+            } catch (Exception e) {
+                Slog.e(TAG, "Exception setSize", e);
+            } finally {
+                SurfaceControl.closeTransaction();
+            }
+        }
+    }
+
+    public void setPosition(int x, int y) {
+        if (mBlurSurface != null && (mX != x || mY != y) ) {
+            SurfaceControl.openTransaction();
+            try {
+                mBlurSurface.setPosition(x, y);
+                mX = x;
+                mY = y;
+            } catch (RuntimeException e) {
+                Slog.w(TAG, "Failure setting setPosition immediately", e);
+            } catch (Exception e) {
+                Slog.e(TAG, "Exception setPosition", e);
+            } finally {
+                SurfaceControl.closeTransaction();
+            }
+        }
+    }
+
+    public void setLayer(int layer) {
+        if (mBlurSurface != null && mLayer != layer) {
+            SurfaceControl.openTransaction();
+            try {
+                mBlurSurface.setLayer(layer);
+                mLayer = layer;
+            } catch (RuntimeException e) {
+                Slog.w(TAG, "Failure setting setLayer immediately", e);
+            } catch (Exception e) {
+                Slog.e(TAG, "Exception setLayer", e);
+            } finally {
+                SurfaceControl.closeTransaction();
+            }
+        }
+    }
+
+    public void setAlpha(float alpha){
+        if(mBlurSurface != null && mAlpha != alpha){
+            SurfaceControl.openTransaction();
+            try {
+                mBlurSurface.setAlpha(alpha);
+                mAlpha = alpha;
+            } catch (RuntimeException e) {
+                Slog.w(TAG, "Failure setting alpha immediately", e);
+            } catch (Exception e) {
+                Slog.e(TAG, "Exception setAlpha", e);
+            } finally {
+                SurfaceControl.closeTransaction();
+            }
+        }
+    }
+
+    public void setBlur(float blur){
+        if(mBlurSurface != null &&  mBlur != blur ){
+            SurfaceControl.openTransaction();
+            try {
+                mBlurSurface.setBlur(blur);
+                mBlur = blur;
+            } catch (RuntimeException e) {
+                Slog.w(TAG, "Failure setting blur immediately", e);
+            } catch (Exception e) {
+                Slog.e(TAG, "Exception setBlur", e);
+            } finally {
+                SurfaceControl.closeTransaction();
+            }
+        }
+    }
+
+    public void show() {
+        if(mBlurSurface != null &&  !mIsShow ){
+            try {
+                mBlurSurface.show();
+                mIsShow = true;
+            } catch (RuntimeException e) {
+                Slog.w(TAG, "Failure show()", e);
+            } catch (Exception e) {
+                Slog.e(TAG, "Exception show()", e);
+            } finally {
+                SurfaceControl.closeTransaction();
+            }
+        }
+    }
+
+    public void hide(){
+        if(mBlurSurface != null &&  mIsShow ){
+            try {
+                mBlurSurface.hide();
+                mIsShow = false;
+            } catch (RuntimeException e) {
+                Slog.w(TAG, "Failure hide()", e);
+            } catch (Exception e) {
+                Slog.e(TAG, "Exception hide()", e);
+            } finally {
+                SurfaceControl.closeTransaction();
+            }
+        }
+    }
+
+    public void destroySurface() {
+        if (DEBUG) Slog.v(TAG, "destroySurface.");
+        if (mBlurSurface != null) {
+            mBlurSurface.destroy();
+            mBlurSurface = null;
+        }
+    }
+
+}
+

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
@@ -2505,6 +2505,10 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
         return mScreenOnComingFromTouch;
     }
 
+    void setBlur(float b){
+        mStatusBarWindowManager.setBlur(b);
+    }
+
     public boolean isFalsingThresholdNeeded() {
         boolean onKeyguard = getBarState() == StatusBarState.KEYGUARD;
         boolean isMethodInsecure = mUnlockMethodCache.isMethodInsecure();
@@ -3476,7 +3480,7 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
     private void addStatusBarWindow() {
         makeStatusBarView();
         mStatusBarWindow.addContent(mStatusBarWindowContent);
-        mStatusBarWindowManager = new StatusBarWindowManager(mContext);
+        mStatusBarWindowManager = new StatusBarWindowManager(mContext, this);
         mStatusBarWindowManager.add(mStatusBarWindow, getStatusBarHeight());
     }
 
@@ -4222,6 +4226,10 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
         }
         updateKeyguardState(staying, false /* fromShadeLocked */);
         return staying;
+    }
+
+    boolean isSecure() {
+        return mStatusBarKeyguardViewManager != null && mStatusBarKeyguardViewManager.isSecure();
     }
 
     public long calculateGoingToFullShadeDelay() {

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBarView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBarView.java
@@ -172,5 +172,6 @@ public class PhoneStatusBarView extends PanelBar {
         super.panelExpansionChanged(panel, frac, expanded);
         mScrimController.setPanelExpansion(frac);
         mBar.updateCarrierLabelVisibility(false);
+        mBar.setBlur(frac);
     }
 }

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarKeyguardViewManager.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarKeyguardViewManager.java
@@ -158,6 +158,7 @@ public class StatusBarKeyguardViewManager {
 
     public void onScreenTurnedOn(final IKeyguardShowCallback callback) {
         mScreenOn = true;
+        mStatusBarWindowManager.onScreenTurnedOn();
         mPhoneStatusBar.onScreenTurnedOn();
         if (callback != null) {
             callbackAfterDraw(callback);

--- a/packages/SystemUI/src/com/android/systemui/volume/VolumePanel.java
+++ b/packages/SystemUI/src/com/android/systemui/volume/VolumePanel.java
@@ -265,6 +265,8 @@ public class VolumePanel extends Handler {
     private static AlertDialog sSafetyWarning;
     private static Object sSafetyWarningLock = new Object();
 
+    private boolean mBlurUiEnabled;
+
     private ContentObserver mSettingsObserver = new ContentObserver(this) {
         @Override
         public void onChange(boolean selfChange) {
@@ -272,7 +274,6 @@ public class VolumePanel extends Handler {
                     Settings.Secure.VOLUME_LINK_NOTIFICATION, 1) == 1;
         }
     };
-
 
     private static class SafetyWarning extends SystemUIDialog
             implements DialogInterface.OnDismissListener, DialogInterface.OnClickListener {
@@ -422,6 +423,7 @@ public class VolumePanel extends Handler {
                     | LayoutParams.FLAG_WATCH_OUTSIDE_TOUCH
                     | LayoutParams.FLAG_HARDWARE_ACCELERATED);
             mView = window.findViewById(R.id.content);
+
             Interaction.register(mView, new Interaction.Callback() {
                 @Override
                 public void onInteraction() {
@@ -461,6 +463,19 @@ public class VolumePanel extends Handler {
 
         registerReceiver();
 
+        boolean blurEnabled = false && context.getResources().getBoolean(R.bool.config_ui_blur_enabled);
+        if (blurEnabled && mDialog != null && mDialog.getWindow() != null) {
+            Window window = mDialog.getWindow();
+            window.addPrivateFlags(WindowManager.LayoutParams.PRIVATE_FLAG_BLUR_WITH_MASKING);
+            window.setBlurMaskAlphaThreshold(0.48f);
+            View mainContainer = window.findViewById(com.android.systemui.R.id.volume_dialog_bg_container);
+            mainContainer.setBackgroundResource(
+                com.android.systemui.R.drawable.volume_dialog_bg_translucent);
+
+            mSliderPanel.setBackground(null);
+            window.findViewById(com.android.systemui.R.id.zen_mode_panel_bg_container)
+                .setBackground(null);
+        }
     }
 
     public VolumePanel(Context context, ZenModeController zenController) {

--- a/policy/src/com/android/internal/policy/impl/GlobalActions.java
+++ b/policy/src/com/android/internal/policy/impl/GlobalActions.java
@@ -1392,6 +1392,11 @@ class GlobalActions implements DialogInterface.OnDismissListener, DialogInterfac
             mAdapter = (MyAdapter) params.mAdapter;
             mWindowTouchSlop = ViewConfiguration.get(context).getScaledWindowTouchSlop();
             params.apply(mAlert);
+
+            if (false && context.getResources().getBoolean(R.bool.config_ui_blur_enabled)) {
+                getWindow().addFlags(WindowManager.LayoutParams.FLAG_BLUR_BEHIND);
+                getWindow().clearFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND);
+            }
         }
 
         private static int getDialogTheme(Context context) {

--- a/services/core/java/com/android/server/wm/BlurLayer.java
+++ b/services/core/java/com/android/server/wm/BlurLayer.java
@@ -1,0 +1,318 @@
+/*
+ * Copyright (c) 2014, The Linux Foundation. All rights reserved.
+ * Not a Contribution.
+ *
+ * Copyright (C) 2014 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.server.wm;
+
+import android.graphics.PixelFormat;
+import android.graphics.Rect;
+import android.os.SystemClock;
+import android.util.Slog;
+import android.view.DisplayInfo;
+import android.view.SurfaceControl;
+
+import java.io.PrintWriter;
+
+public class BlurLayer {
+    private static final String TAG = "BlurLayer";
+    private static final boolean DEBUG = false;
+
+    /** Reference to the owner of this object. */
+    final DisplayContent mDisplayContent;
+
+    /** Actual surface that blurs */
+    SurfaceControl mBlurSurface;
+
+    /** Last value passed to mBlurSurface.setBlur() */
+    float mBlur = 0;
+
+    /** Last value passed to mBlurSurface.setLayer() */
+    int mLayer = -1;
+
+    /** Next values to pass to mBlurSurface.setPosition() and mBlurSurface.setSize() */
+    Rect mBounds = new Rect();
+
+    /** Last values passed to mBlurSurface.setPosition() and mBlurSurface.setSize() */
+    Rect mLastBounds = new Rect();
+
+    /** True after mBlurSurface.show() has been called, false after mBlurSurface.hide(). */
+    private boolean mShowing = false;
+
+    /** Value of mBlur when beginning transition to mTargetBlur */
+    float mStartBlur = 0;
+
+    /** Final value of mBlur following transition */
+    float mTargetBlur = 0;
+
+    /** Time in units of SystemClock.uptimeMillis() at which the current transition started */
+    long mStartTime;
+
+    /** Time in milliseconds to take to transition from mStartBlur to mTargetBlur */
+    long mDuration;
+
+    /** Owning stack */
+    final TaskStack mStack;
+
+    BlurLayer(WindowManagerService service, TaskStack stack, DisplayContent displayContent) {
+        mStack = stack;
+        mDisplayContent = displayContent;
+        final int displayId = mDisplayContent.getDisplayId();
+        if (DEBUG) Slog.v(TAG, "Ctor: displayId=" + displayId);
+        SurfaceControl.openTransaction();
+        try {
+            if (WindowManagerService.DEBUG_SURFACE_TRACE) {
+                mBlurSurface = new WindowStateAnimator.SurfaceTrace(service.mFxSession,
+                    "BlurSurface",
+                    16, 16, PixelFormat.OPAQUE,
+                    SurfaceControl.FX_SURFACE_BLUR | SurfaceControl.HIDDEN);
+            } else {
+                mBlurSurface = new SurfaceControl(service.mFxSession, TAG,
+                    16, 16, PixelFormat.OPAQUE,
+                    SurfaceControl.FX_SURFACE_BLUR | SurfaceControl.HIDDEN);
+            }
+            if (WindowManagerService.SHOW_TRANSACTIONS ||
+                    WindowManagerService.SHOW_SURFACE_ALLOC) Slog.i(TAG,
+                            "  BLUR " + mBlurSurface + ": CREATE");
+            mBlurSurface.setLayerStack(displayId);
+        } catch (Exception e) {
+            Slog.e(WindowManagerService.TAG, "Exception creating Blur surface", e);
+        } finally {
+            SurfaceControl.closeTransaction();
+        }
+    }
+
+    /** Return true if blur layer is showing */
+    boolean isBlurring() {
+        return mTargetBlur != 0;
+    }
+
+    /** Return true if in a transition period */
+    boolean isAnimating() {
+        return mTargetBlur != mBlur;
+    }
+
+    float getTargetBlur() {
+        return mTargetBlur;
+    }
+
+    void setLayer(int layer) {
+        if (mLayer != layer) {
+            mLayer = layer;
+            mBlurSurface.setLayer(layer);
+        }
+    }
+
+    int getLayer() {
+        return mLayer;
+    }
+
+    private void setBlur(float blur) {
+        if (mBlur != blur) {
+            if (DEBUG) Slog.v(TAG, "setBlur blur=" + blur);
+            try {
+                mBlurSurface.setBlur(blur);
+                if (blur == 0 && mShowing) {
+                    if (DEBUG) Slog.v(TAG, "setBlur hiding");
+                    mBlurSurface.hide();
+                    mShowing = false;
+                } else if (blur > 0 && !mShowing) {
+                    if (DEBUG) Slog.v(TAG, "setBlur showing");
+                    mBlurSurface.show();
+                    mShowing = true;
+                }
+            } catch (RuntimeException e) {
+                Slog.w(TAG, "Failure setting blur immediately", e);
+            }
+            mBlur = blur;
+        }
+    }
+
+    void adjustSurface(int layer, boolean inTransaction) {
+        final int dw, dh;
+        final float xPos, yPos;
+        if (!mStack.isFullscreen()) {
+            dw = mBounds.width();
+            dh = mBounds.height();
+            xPos = mBounds.left;
+            yPos = mBounds.top;
+        } else {
+            // Set surface size to screen size.
+            final DisplayInfo info = mDisplayContent.getDisplayInfo();
+            dw = info.logicalWidth;
+            dh = info.logicalHeight;
+            xPos = 0;
+            yPos = 0;
+        }
+
+        try {
+            if (!inTransaction) {
+                SurfaceControl.openTransaction();
+            }
+            mBlurSurface.setPosition(xPos, yPos);
+            mBlurSurface.setSize(dw, dh);
+            mBlurSurface.setLayer(layer);
+        } catch (RuntimeException e) {
+            Slog.w(TAG, "Failure setting size or layer", e);
+        } finally {
+            if (!inTransaction) {
+                SurfaceControl.closeTransaction();
+            }
+        }
+        mLastBounds.set(mBounds);
+        mLayer = layer;
+    }
+
+    void setBounds(Rect bounds) {
+        mBounds.set(bounds);
+        if (isBlurring() && !mLastBounds.equals(bounds)) {
+            adjustSurface(mLayer, false);
+        }
+    }
+
+    /**
+     * @param duration The time to test.
+     * @return True if the duration would lead to an earlier end to the current animation.
+     */
+    private boolean durationEndsEarlier(long duration) {
+        return SystemClock.uptimeMillis() + duration < mStartTime + mDuration;
+    }
+
+    /** Jump to the end of the animation.
+     * NOTE: Must be called with Surface transaction open. */
+    void show() {
+        if (isAnimating()) {
+            if (DEBUG) Slog.v(TAG, "show: immediate");
+            show(mLayer, mTargetBlur, 0);
+        }
+    }
+
+    /**
+     * Begin an animation to a new dim value.
+     * NOTE: Must be called with Surface transaction open.
+     *
+     * @param layer The layer to set the surface to.
+     * @param blur The dim value to end at.
+     * @param duration How long to take to get there in milliseconds.
+     */
+    void show(int layer, float blur, long duration) {
+        if (DEBUG) Slog.v(TAG, "show: layer=" + layer + " blur=" + blur
+                + " duration=" + duration);
+        if (mBlurSurface == null) {
+            Slog.e(TAG, "show: no Surface");
+            // Make sure isAnimating() returns false.
+            mTargetBlur = mBlur = 0;
+            return;
+        }
+
+        if (!mLastBounds.equals(mBounds) || mLayer != layer) {
+            adjustSurface(layer, true);
+        }
+
+        long curTime = SystemClock.uptimeMillis();
+        final boolean animating = isAnimating();
+        if ((animating && (mTargetBlur != blur || durationEndsEarlier(duration)))
+                || (!animating && mBlur != blur)) {
+            if (duration <= 0) {
+                // No animation required, just set values.
+                setBlur(blur);
+            } else {
+                // Start or continue animation with new parameters.
+                mStartBlur = mBlur;
+                mStartTime = curTime;
+                mDuration = duration;
+            }
+        }
+        if (DEBUG) Slog.v(TAG, "show: mStartBlur=" + mStartBlur + " mStartTime=" + mStartTime);
+        mTargetBlur = blur;
+    }
+
+    /** Immediate hide.
+     * NOTE: Must be called with Surface transaction open. */
+    void hide() {
+        if (mShowing) {
+            if (DEBUG) Slog.v(TAG, "hide: immediate");
+            hide(0);
+        }
+    }
+
+    /**
+     * Gradually fade to transparent.
+     * NOTE: Must be called with Surface transaction open.
+     *
+     * @param duration Time to fade in milliseconds.
+     */
+    void hide(long duration) {
+        if (mShowing && (mTargetBlur != 0 || durationEndsEarlier(duration))) {
+            if (DEBUG) Slog.v(TAG, "hide: duration=" + duration);
+            show(mLayer, 0, duration);
+        }
+    }
+
+    /**
+     * Advance the dimming per the last #show(int, float, long) call.
+     * NOTE: Must be called with Surface transaction open.
+     *
+     * @return True if animation is still required after this step.
+     */
+    boolean stepAnimation() {
+        if (mBlurSurface == null) {
+            Slog.e(TAG, "stepAnimation: null Surface");
+            // Ensure that isAnimating() returns false;
+            mTargetBlur = mBlur = 0;
+            return false;
+        }
+
+        if (isAnimating()) {
+            final long curTime = SystemClock.uptimeMillis();
+            final float blurDelta = mTargetBlur - mStartBlur;
+            float blur = mStartBlur + blurDelta * (curTime - mStartTime) / mDuration;
+            if (blurDelta > 0 && blur > mTargetBlur ||
+                    blurDelta < 0 && blur < mTargetBlur) {
+                // Don't exceed limits.
+                blur = mTargetBlur;
+            }
+            if (DEBUG) Slog.v(TAG, "stepAnimation: curTime=" + curTime + " blur=" + blur);
+            setBlur(blur);
+        }
+
+        return isAnimating();
+    }
+
+    /** Cleanup */
+    void destroySurface() {
+        if (DEBUG) Slog.v(TAG, "destroySurface.");
+        if (mBlurSurface != null) {
+            mBlurSurface.destroy();
+            mBlurSurface = null;
+        }
+    }
+
+    public void printTo(String prefix, PrintWriter pw) {
+        pw.print(prefix); pw.print("mBlurSurface="); pw.print(mBlurSurface);
+                pw.print(" mLayer="); pw.print(mLayer);
+                pw.print(" mBlur="); pw.println(mBlur);
+        pw.print(prefix); pw.print("mLastBounds="); pw.print(mLastBounds.toShortString());
+                pw.print(" mBounds="); pw.println(mBounds.toShortString());
+        pw.print(prefix); pw.print("Last animation: ");
+                pw.print(" mDuration="); pw.print(mDuration);
+                pw.print(" mStartTime="); pw.print(mStartTime);
+                pw.print(" curTime="); pw.println(SystemClock.uptimeMillis());
+        pw.print(prefix); pw.print(" mStartBlur="); pw.print(mStartBlur);
+                pw.print(" mTargetBlur="); pw.println(mTargetBlur);
+    }
+}

--- a/services/core/java/com/android/server/wm/DisplayContent.java
+++ b/services/core/java/com/android/server/wm/DisplayContent.java
@@ -296,6 +296,35 @@ class DisplayContent {
         }
     }
 
+    boolean animateBlurLayers() {
+        boolean result = false;
+        for (int stackNdx = mStacks.size() - 1; stackNdx >= 0; --stackNdx) {
+            result |= mStacks.get(stackNdx).animateBlurLayers();
+        }
+        return result;
+    }
+
+    void resetBlurring() {
+        for (int stackNdx = mStacks.size() - 1; stackNdx >= 0; --stackNdx) {
+            mStacks.get(stackNdx).resetBlurringTag();
+        }
+    }
+
+    boolean isBlurring() {
+        for (int stackNdx = mStacks.size() - 1; stackNdx >= 0; --stackNdx) {
+            if (mStacks.get(stackNdx).isBlurring()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    void stopBlurringIfNeeded() {
+        for (int stackNdx = mStacks.size() - 1; stackNdx >= 0; --stackNdx) {
+            mStacks.get(stackNdx).stopBlurringIfNeeded();
+        }
+    }
+
     void close() {
         for (int stackNdx = mStacks.size() - 1; stackNdx >= 0; --stackNdx) {
             mStacks.get(stackNdx).close();

--- a/services/core/java/com/android/server/wm/WindowStateAnimator.java
+++ b/services/core/java/com/android/server/wm/WindowStateAnimator.java
@@ -100,6 +100,13 @@ class WindowStateAnimator {
 
     SurfaceControl mSurfaceControl;
     SurfaceControl mPendingDestroySurface;
+    int mLayerStack;
+
+    SurfaceControl mSurfaceControlBlur;
+    SurfaceControl mPendingDestroySurfaceBlur;
+    boolean mSurfaceBlurShown;  // last value
+    boolean mSurfaceBlurScaleNeeded;
+    final static int BLUR_LAYER_OFFSET = WindowManagerService.LAYER_OFFSET_BLUR_WITH_MASKING;
 
     /**
      * Set when we have changed the size of the surface, to know that
@@ -467,6 +474,12 @@ class WindowStateAnimator {
                     mSurfaceControl.hide();
                 } catch (RuntimeException e) {
                     Slog.w(TAG, "Exception hiding surface in " + mWin);
+                }
+                if (mSurfaceControlBlur != null) {
+                    try { mSurfaceControlBlur.hide(); }
+                    catch (RuntimeException e) {
+                        Slog.w(TAG, "Exception hiding surface blur in " + mWin);
+                    }
                 }
             }
         }
@@ -880,7 +893,8 @@ class WindowStateAnimator {
                     mSurfaceLayer = mAnimLayer;
                     final DisplayContent displayContent = w.getDisplayContent();
                     if (displayContent != null) {
-                        mSurfaceControl.setLayerStack(displayContent.getDisplay().getLayerStack());
+                        mLayerStack = displayContent.getDisplay().getLayerStack();
+                        mSurfaceControl.setLayerStack(mLayerStack);
                     }
                     mSurfaceControl.setLayer(mAnimLayer);
                     mSurfaceControl.setAlpha(0);
@@ -897,6 +911,7 @@ class WindowStateAnimator {
             }
             if (WindowManagerService.localLOGV) Slog.v(
                     TAG, "Created surface " + this);
+            updateBlurWithMaskingState(attrs, false);
         }
         return mSurfaceControl;
     }
@@ -940,6 +955,13 @@ class WindowStateAnimator {
                         }
                         mPendingDestroySurface = mSurfaceControl;
                     }
+
+                    if (mSurfaceControlBlur != null && mPendingDestroySurfaceBlur != mSurfaceControlBlur) {
+                        if (mPendingDestroySurfaceBlur != null) {
+                            mPendingDestroySurfaceBlur.destroy();
+                        }
+                        mPendingDestroySurfaceBlur = mSurfaceControlBlur;
+                    }
                 } else {
                     if (SHOW_TRANSACTIONS || SHOW_SURFACE_ALLOC) {
                         RuntimeException e = null;
@@ -950,6 +972,9 @@ class WindowStateAnimator {
                         WindowManagerService.logSurface(mWin, "DESTROY", e);
                     }
                     mSurfaceControl.destroy();
+                    if (mSurfaceControlBlur != null) {
+                        mSurfaceControlBlur.destroy();
+                    }
                 }
                 mAnimator.hideWallpapersLocked(mWin);
             } catch (RuntimeException e) {
@@ -960,6 +985,7 @@ class WindowStateAnimator {
 
             mSurfaceShown = false;
             mSurfaceControl = null;
+            mSurfaceControlBlur = null;
             mWin.mHasSurface = false;
             mDrawState = NO_SURFACE;
         }
@@ -982,6 +1008,9 @@ class WindowStateAnimator {
                     WindowManagerService.logSurface(mWin, "DESTROY PENDING", e);
                 }
                 mPendingDestroySurface.destroy();
+                if (mPendingDestroySurfaceBlur != null) {
+                    mPendingDestroySurfaceBlur.destroy();
+                }
                 mAnimator.hideWallpapersLocked(mWin);
             }
         } catch (RuntimeException e) {
@@ -991,6 +1020,7 @@ class WindowStateAnimator {
         }
         mSurfaceDestroyDeferred = false;
         mPendingDestroySurface = null;
+        mPendingDestroySurfaceBlur = null;
     }
 
     void computeShownFrameLocked() {
@@ -1389,6 +1419,9 @@ class WindowStateAnimator {
                 if (WindowManagerService.SHOW_TRANSACTIONS) WindowManagerService.logSurface(w,
                         "POS " + left + ", " + top, null);
                 mSurfaceControl.setPosition(left, top);
+                if (mSurfaceControlBlur != null) {
+                    mSurfaceControlBlur.setPosition(left, top);
+                }
             } catch (RuntimeException e) {
                 Slog.w(TAG, "Error positioning surface of " + w
                         + " pos=(" + left + "," + top + ")", e);
@@ -1408,12 +1441,21 @@ class WindowStateAnimator {
                 if (WindowManagerService.SHOW_TRANSACTIONS) WindowManagerService.logSurface(w,
                         "SIZE " + width + "x" + height, null);
                 mSurfaceControl.setSize(width, height);
+                if (mSurfaceControlBlur != null) {
+                    mSurfaceControlBlur.setSize(width, height);
+                }
                 mAnimator.setPendingLayoutChanges(w.getDisplayId(),
                         WindowManagerPolicy.FINISH_LAYOUT_REDO_WALLPAPER);
                 if ((w.mAttrs.flags & LayoutParams.FLAG_DIM_BEHIND) != 0) {
                     final TaskStack stack = w.getStack();
                     if (stack != null) {
                         stack.startDimmingIfNeeded(this);
+                    }
+                }
+                if ((w.mAttrs.flags & LayoutParams.FLAG_BLUR_BEHIND) != 0) {
+                    final TaskStack stack = w.getStack();
+                    if (stack != null) {
+                        stack.startBlurringIfNeeded(this);
                     }
                 }
             } catch (RuntimeException e) {
@@ -1500,6 +1542,14 @@ class WindowStateAnimator {
                     mSurfaceControl.setMatrix(
                             mDsDx * w.mHScale, mDtDx * w.mVScale,
                             mDsDy * w.mHScale, mDtDy * w.mVScale);
+
+                    if (mSurfaceControlBlur != null) {
+                        mSurfaceControlBlur.setAlpha(mShownAlpha);
+                        mSurfaceControlBlur.setLayer(mAnimLayer-BLUR_LAYER_OFFSET);
+                        mSurfaceControlBlur.setMatrix(
+                            mDsDx*w.mHScale, mDtDx*w.mVScale,
+                            mDsDy*w.mHScale, mDtDy*w.mVScale);
+                    }
 
                     if (mLastHidden && mDrawState == HAS_DRAWN) {
                         if (WindowManagerService.SHOW_TRANSACTIONS) WindowManagerService.logSurface(w,
@@ -1591,6 +1641,9 @@ class WindowStateAnimator {
                 if (WindowManagerService.SHOW_TRANSACTIONS) WindowManagerService.logSurface(mWin,
                         "POS " + left + ", " + top, null);
                 mSurfaceControl.setPosition(mWin.mFrame.left + left, mWin.mFrame.top + top);
+                if (mSurfaceControlBlur != null) {
+                    mSurfaceControlBlur.setPosition(mWin.mFrame.left + left, mWin.mFrame.top + top);
+                }
                 updateSurfaceWindowCrop(false);
             } catch (RuntimeException e) {
                 Slog.w(TAG, "Error positioning surface of " + mWin
@@ -1733,6 +1786,9 @@ class WindowStateAnimator {
             if (mSurfaceControl != null) {
                 mSurfaceShown = true;
                 mSurfaceControl.show();
+                if (mSurfaceControlBlur != null) {
+                    mSurfaceControlBlur.show();
+                }
                 if (mWin.mTurnOnScreen) {
                     if (DEBUG_VISIBILITY) Slog.v(TAG,
                             "Show surface turning screen on: " + mWin);
@@ -1918,4 +1974,67 @@ class WindowStateAnimator {
             mFullyTransparent = fullyTransparent;
         }
     }
+
+    void updateBlurWithMaskingState(WindowManager.LayoutParams attrs, boolean hideForced) {
+        boolean blurVisible = !hideForced && 0 != (attrs.privateFlags &
+                (WindowManager.LayoutParams.PRIVATE_FLAG_BLUR_WITH_MASKING |
+                 WindowManager.LayoutParams.PRIVATE_FLAG_BLUR_WITH_MASKING_SCALED) );
+        boolean blurScaleNeeded = blurVisible && 0 != (attrs.privateFlags &
+                WindowManager.LayoutParams.PRIVATE_FLAG_BLUR_WITH_MASKING_SCALED);
+
+        if (mSurfaceBlurShown == blurVisible && mSurfaceBlurScaleNeeded == blurScaleNeeded) return;
+        mSurfaceBlurShown = blurVisible;
+        mSurfaceBlurScaleNeeded = blurScaleNeeded;
+
+        if (!blurVisible) {
+            // we don't destroy mSurfaceControlBlur
+            if (mSurfaceControlBlur != null) {
+                mSurfaceControlBlur.hide();
+            } else {
+                // nothing to do
+            }
+            return;
+        }
+
+        if (mSurfaceControl == null) return;
+
+        if (blurVisible) {
+            if (null == mSurfaceControlBlur) {
+                int flags = SurfaceControl.HIDDEN | SurfaceControl.FX_SURFACE_BLUR;
+                final boolean isHwAccelerated = (attrs.flags &
+                        WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED) != 0;
+                final int format = isHwAccelerated ? PixelFormat.TRANSLUCENT : attrs.format;
+                if (!PixelFormat.formatHasAlpha(attrs.format)) {
+                    flags |= SurfaceControl.OPAQUE;
+                }
+
+                mSurfaceControlBlur = new SurfaceControl(
+                    mSession.mSurfaceSession,
+                    attrs.getTitle().toString() + " blur",
+                    (int)mSurfaceW, (int)mSurfaceH, format, flags);
+            }
+
+            SurfaceControl.openTransaction();
+            try {
+                mSurfaceControlBlur.setPosition(mSurfaceX, mSurfaceY);
+                mSurfaceControlBlur.setLayerStack(mLayerStack);
+                mSurfaceControlBlur.setLayer(mAnimLayer-BLUR_LAYER_OFFSET);
+                mSurfaceControlBlur.setAlpha(mShownAlpha);
+                mSurfaceControlBlur.setBlur(1.0f);
+                mSurfaceControlBlur.setBlurMaskSurface(mSurfaceControl);
+                final int BLUR_MASKING_SAMPLING = 4;
+                mSurfaceControlBlur.setBlurMaskSampling(blurScaleNeeded ? BLUR_MASKING_SAMPLING : 1);
+                mSurfaceControlBlur.setBlurMaskAlphaThreshold(attrs.blurMaskAlphaThreshold);
+            } catch (RuntimeException e) {
+                Slog.w(TAG, "Error creating blur surface", e);
+            } finally {
+                SurfaceControl.closeTransaction();
+            }
+
+            if (mSurfaceShown) {
+                mSurfaceControlBlur.show();
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
Upper level changes to expose blur-behind and blur-mask effect

Change-Id: I6d37b43888c8c5e028974bd714596d8178cb5114

WindowManager: Adding template for BlurLayer file

Cyanogen changes:
- Use config.xml instead of settings
- Don't break stuff if not supported in SF
- Incremental fade for insecure lockscreen
- Disabled extra effects for now

Change-Id: Icefe452f7a015656661e8543849c9b88889dbb40
